### PR TITLE
ANES3-369 | define global fonts

### DIFF
--- a/src/components/global/page-footer.tsx
+++ b/src/components/global/page-footer.tsx
@@ -17,7 +17,7 @@ const PageFooter = ({...props}: Props) => {
       <SuperFooter />
       <LocalFooter />
 
-      <div className="bg-black pb-50 text-white">
+      <div className="bg-black pb-50 font-sans text-white">
         <div className="centered mx-auto w-full xl:max-w-1130">
           <div className="text-16 flex flex-col justify-between gap-10 pt-24 pb-12 lg:flex-row lg:gap-50">
             <div className="shrink-0 font-semibold">
@@ -54,7 +54,7 @@ const PageFooter = ({...props}: Props) => {
             </ul>
           </div>
           <div className="mr-142 mb-18 w-314 max-lg:pt-30 lg:ml-auto lg:w-400 [&_a]:text-white [&_a]:underline [&_a:hocus]:text-white">
-            <h4 className="text-21 leading-cozy mt-14 mb-0">Non-Discrimination</h4>
+            <h4 className="text-21 leading-cozy mt-14 mb-0 font-sans">Non-Discrimination</h4>
             <p className="text-16 mb-0 font-semibold">
               Stanford complies with all applicable civil rights laws and does not engage in illegal preferences or
               discrimination.

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -28,6 +28,21 @@
   --shadow-glass: 0 2px 1px 0 #abd1d0;
 }
 
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: theme(--font-lato);
+  }
+
+  body {
+    font-family: theme(--font-merriweather);
+  }
+}
+
 @layer components {
   .local-footer .wysiwyg h2 {
     font-size: 1.5em;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- ANES3-369 | define global fonts

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to homepage preview
2. Verify that `merriweather` is the global font family and `lato` is the global heading font family
3. Verify that the footer has not changed (compare to test/dev: https://anes-nextjs-git-test-sws-developers-projects.vercel.app/)
4. Review code

# Related Issues/PR's
- ANES3-369
