### PR TITLE
ANES3-383: Added comma to formatted stat number

### DIFF
--- a/src/components/elements/count-up.tsx
+++ b/src/components/elements/count-up.tsx
@@ -50,12 +50,17 @@ const CountUpNumber = ({
     }
   }, [motionValue, end, isInView])
 
-  const formattedValue = decimals > 0 ? displayValue.toFixed(decimals) : Math.floor(displayValue).toString()
+  const numericValue = decimals > 0 ? displayValue : Math.floor(displayValue)
+  const formattedValue = decimals > 0 ? numericValue.toFixed(decimals) : numericValue.toString()
+  const formattedValueWithCommas = Intl.NumberFormat(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(Number(formattedValue))
 
   return (
     <motion.span ref={ref} className={className} {...props}>
       {prefix}
-      {formattedValue}
+      {formattedValueWithCommas}
       {suffix}
     </motion.span>
   )

--- a/src/lib/gql/__generated__/drupal.d.tsx
+++ b/src/lib/gql/__generated__/drupal.d.tsx
@@ -1517,6 +1517,8 @@ export type NodeStanfordNews = EdgeNode &
     id: Scalars["ID"]["output"]
     /** Language */
     langcode: Language
+    /** Layout */
+    layoutSelection?: Maybe<LayoutLibrary>
     /** The computed meta tags for the entity. */
     metatag: Array<MetaTagUnion>
     /** URL alias */
@@ -1548,21 +1550,37 @@ export type NodeStanfordNews = EdgeNode &
      */
     suNewsDek?: Maybe<Scalars["String"]["output"]>
     /**
-     * Maximum one featured media. <em>The “featured media” will appear as a
-     * thumbnail on the list page, and as a thumbnail on the teaser card
-     * paragraph.</em>
+     * Maximum of one featured media item. <em>The featured media will appear as a
+     * thumbnail on the list page and on the teaser card paragraph.</em> The
+     * alternative text for the image should not be just the image or person’s
+     * name. The image should either be marked as decorative, or the alternative text
+     * should describe the image. See the <a
+     * Guide: Alternative text (alt text) for images and other media</a> for
+     * additional information.
      */
     suNewsFeaturedMedia?: Maybe<MediaImage>
     /** Hide Social Share Icons */
     suNewsHideSocial?: Maybe<Scalars["Boolean"]["output"]>
+    /** Related Person */
+    suNewsPerson?: Maybe<Array<NodeStanfordPerson>>
     /** <em>The “publishing date” will appear next to the “byline” below the headline and dek on the article page.</em> */
     suNewsPublishingDate?: Maybe<DateTime>
+    /** Quote / Big Text */
+    suNewsQuote?: Maybe<Scalars["String"]["output"]>
     /**
      * Add a URL to an external source for this news item such as
      * https://example.com/. By adding an external source URL all listings of this
      * news article will link to the external source instead of a page on this
      */
     suNewsSource?: Maybe<Link>
+    /**
+     * Enter the categories associated with this spotlight. These will be used in two
+     * ways: displayed in the content on the individual spotlight page, and as
+     * filters for the Filtered Lists Paragraph view.
+     */
+    suNewsSpotlightFilters?: Maybe<Array<TermStanfordNewsSpotlightFilter>>
+    /** Subtitle */
+    suNewsSubtitle?: Maybe<Scalars["String"]["output"]>
     /**
      * Add all News Type terms for this article. Note: Only the top three selected
      * terms will be displayed to the end-users. The complete list of terms will be
@@ -1686,13 +1704,6 @@ export type NodeStanfordOpportunity = EdgeNode &
      */
     suOppImage?: Maybe<MediaImage>
     /**
-     * Provide a internal or external link where users can find out more about this
-     * opportunity. Please ensure this link has text that describes where the link
-     */
-    suOppLearnMore?: Maybe<Link>
-    /** The date that applications or registration is first available. */
-    suOppOpenDate?: Maybe<DateTime>
-    /**
      * This field is used for indicating prerequisites to participate in this
      * opportunity. Common uses include course pre-requisites, language experience,
      * skills needed, etc. This displays on the individual opportunity page.
@@ -1708,10 +1719,6 @@ export type NodeStanfordOpportunity = EdgeNode &
     suOppSource?: Maybe<Link>
     /** Who sponsors this opportunity. */
     suOppSponsor?: Maybe<Array<TermOpportunitySponsor>>
-    /** The date the Opportunity starts. */
-    suOppStartDate?: Maybe<DateTime>
-    /** Status of the Opportunity. Check this box if the Opportunity should be listed as "Closed." */
-    suOppStatus?: Maybe<Scalars["Boolean"]["output"]>
     /**
      * Use this field to provide a short summary about the opportunity. This will
      * appear on card displays on Teasers, Lists Paragraphs, and Filtered Lists
@@ -4436,6 +4443,34 @@ export type TermStanfordEventType = MetaTagInterface &
     weight: Scalars["Int"]["output"]
   }
 
+/** Entity type taxonomy_term. */
+export type TermStanfordNewsSpotlightFilter = MetaTagInterface &
+  TermInterface & {
+    __typename?: "TermStanfordNewsSpotlightFilter"
+    /** The time that the term was last edited. */
+    changed: DateTime
+    /** Description */
+    description: Text
+    /** The entity ID. */
+    id: Scalars["ID"]["output"]
+    /** The term language code. */
+    langcode: Language
+    /** The computed meta tags for the entity. */
+    metatag: Array<MetaTagUnion>
+    /** Name */
+    name: Scalars["String"]["output"]
+    /** The parents of this term. */
+    parent?: Maybe<TermUnion>
+    /** URL alias */
+    path?: Maybe<Scalars["String"]["output"]>
+    /** Published */
+    status: Scalars["Boolean"]["output"]
+    /** The Universally Unique IDentifier (UUID). */
+    uuid: Scalars["ID"]["output"]
+    /** The weight of this term in relation to other terms. */
+    weight: Scalars["Int"]["output"]
+  }
+
 /** Broad categories that specify a type of News article. (i.e. Blog) */
 export type TermStanfordNewsTopic = MetaTagInterface &
   TermInterface & {
@@ -4621,6 +4656,7 @@ export type TermUnion =
   | TermStanfordEventKeyword
   | TermStanfordEventSubject
   | TermStanfordEventType
+  | TermStanfordNewsSpotlightFilter
   | TermStanfordNewsTopic
   | TermStanfordPersonType
   | TermStanfordPublicationTopic
@@ -4802,6 +4838,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -4830,6 +4867,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -4858,6 +4896,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -4915,6 +4954,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5095,6 +5135,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5123,6 +5164,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5217,6 +5259,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5245,6 +5288,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5468,6 +5512,7 @@ export type NodeQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5498,6 +5543,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5712,6 +5758,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5728,7 +5775,6 @@ export type NodeQuery = {
         suOppContactName?: string | null
         suOppContactPhone?: any | null
         suOppCourseCode?: Array<string> | null
-        suOppStatus?: boolean | null
         uuid: string
         title: string
         path?: string | null
@@ -5902,8 +5948,6 @@ export type NodeQuery = {
           name: string
           mediaImage: {__typename?: "Image"; url: string; alt?: string | null; height: number; width: number}
         } | null
-        suOppLearnMore?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
-        suOppOpenDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
         suOppPrerequisites?: {__typename?: "Text"; processed?: any | null} | null
         suOppSource?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
         suOppSponsor?: Array<{
@@ -5926,6 +5970,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5934,7 +5979,6 @@ export type NodeQuery = {
             | {__typename?: "TermSuCourseTag"; uuid: string}
             | null
         }> | null
-        suOppStartDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
         suOppSummary?: {__typename?: "Text"; processed?: any | null} | null
         suOppTags?: Array<{
           __typename: "TermOpportunityTagFilter"
@@ -5956,6 +6000,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -5984,6 +6029,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -6012,6 +6058,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -6064,6 +6111,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -6505,6 +6553,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -6798,6 +6847,7 @@ export type NodeQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7202,6 +7252,7 @@ export type CoursesQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7230,6 +7281,7 @@ export type CoursesQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7258,6 +7310,7 @@ export type CoursesQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7479,6 +7532,7 @@ export type EventSeriesQuery = {
             | {__typename?: "TermStanfordEventKeyword"; uuid: string}
             | {__typename?: "TermStanfordEventSubject"; uuid: string}
             | {__typename?: "TermStanfordEventType"; uuid: string}
+            | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
             | {__typename?: "TermStanfordNewsTopic"; uuid: string}
             | {__typename?: "TermStanfordPersonType"; uuid: string}
             | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7509,6 +7563,7 @@ export type EventSeriesQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7564,6 +7619,7 @@ export type EventsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7744,6 +7800,7 @@ export type EventsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7772,6 +7829,7 @@ export type EventsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7866,6 +7924,7 @@ export type EventsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -7894,6 +7953,7 @@ export type EventsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8106,6 +8166,7 @@ export type NewsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8156,6 +8217,7 @@ export type BasicPagesQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8595,6 +8657,7 @@ export type PeopleQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8884,6 +8947,7 @@ export type PublicationsQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8958,6 +9022,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -8986,6 +9051,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9014,6 +9080,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9042,6 +9109,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9070,6 +9138,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9098,6 +9167,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9126,6 +9196,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9154,6 +9225,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9182,6 +9254,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9210,6 +9283,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9238,6 +9312,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9266,6 +9341,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9294,6 +9370,36 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
+          | {__typename?: "TermStanfordNewsTopic"; uuid: string}
+          | {__typename?: "TermStanfordPersonType"; uuid: string}
+          | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
+          | {__typename?: "TermSuCourseQuarter"; uuid: string}
+          | {__typename?: "TermSuCourseSubject"; uuid: string}
+          | {__typename?: "TermSuCourseTag"; uuid: string}
+          | null
+      }
+    | {
+        __typename: "TermStanfordNewsSpotlightFilter"
+        uuid: string
+        name: string
+        path?: string | null
+        weight: number
+        parent?:
+          | {__typename?: "TermBasicPageType"; uuid: string}
+          | {__typename?: "TermEventAudience"; uuid: string}
+          | {__typename?: "TermEventFilter"; uuid: string}
+          | {__typename?: "TermOpportunitySponsor"; uuid: string}
+          | {__typename?: "TermOpportunityTagFilter"; uuid: string}
+          | {__typename?: "TermOpportunityType"; uuid: string}
+          | {__typename?: "TermOpportunityUnit"; uuid: string}
+          | {__typename?: "TermPersonFilter"; uuid: string}
+          | {__typename?: "TermPublicationFilter"; uuid: string}
+          | {__typename?: "TermStanfordEventGroup"; uuid: string}
+          | {__typename?: "TermStanfordEventKeyword"; uuid: string}
+          | {__typename?: "TermStanfordEventSubject"; uuid: string}
+          | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9322,6 +9428,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9350,6 +9457,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9378,6 +9486,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9406,6 +9515,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9434,6 +9544,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9462,6 +9573,7 @@ export type TermQuery = {
           | {__typename?: "TermStanfordEventKeyword"; uuid: string}
           | {__typename?: "TermStanfordEventSubject"; uuid: string}
           | {__typename?: "TermStanfordEventType"; uuid: string}
+          | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
           | {__typename?: "TermStanfordNewsTopic"; uuid: string}
           | {__typename?: "TermStanfordPersonType"; uuid: string}
           | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9500,6 +9612,7 @@ export type OpportunityFiltersTermsQuery = {
         | {__typename?: "TermStanfordEventKeyword"; uuid: string}
         | {__typename?: "TermStanfordEventSubject"; uuid: string}
         | {__typename?: "TermStanfordEventType"; uuid: string}
+        | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
         | {__typename?: "TermStanfordNewsTopic"; uuid: string}
         | {__typename?: "TermStanfordPersonType"; uuid: string}
         | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9863,6 +9976,7 @@ type FragmentTermInterface_TermBasicPageType_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9892,6 +10006,7 @@ type FragmentTermInterface_TermEventAudience_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9921,6 +10036,7 @@ type FragmentTermInterface_TermEventFilter_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9950,6 +10066,7 @@ type FragmentTermInterface_TermOpportunitySponsor_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -9979,6 +10096,7 @@ type FragmentTermInterface_TermOpportunityTagFilter_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10008,6 +10126,7 @@ type FragmentTermInterface_TermOpportunityType_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10037,6 +10156,7 @@ type FragmentTermInterface_TermOpportunityUnit_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10066,6 +10186,7 @@ type FragmentTermInterface_TermPersonFilter_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10095,6 +10216,7 @@ type FragmentTermInterface_TermPublicationFilter_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10124,6 +10246,7 @@ type FragmentTermInterface_TermStanfordEventGroup_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10153,6 +10276,7 @@ type FragmentTermInterface_TermStanfordEventKeyword_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10182,6 +10306,7 @@ type FragmentTermInterface_TermStanfordEventSubject_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10211,6 +10336,37 @@ type FragmentTermInterface_TermStanfordEventType_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
+    | {__typename?: "TermStanfordNewsTopic"; uuid: string}
+    | {__typename?: "TermStanfordPersonType"; uuid: string}
+    | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
+    | {__typename?: "TermSuCourseQuarter"; uuid: string}
+    | {__typename?: "TermSuCourseSubject"; uuid: string}
+    | {__typename?: "TermSuCourseTag"; uuid: string}
+    | null
+}
+
+type FragmentTermInterface_TermStanfordNewsSpotlightFilter_Fragment = {
+  __typename: "TermStanfordNewsSpotlightFilter"
+  uuid: string
+  name: string
+  path?: string | null
+  weight: number
+  parent?:
+    | {__typename?: "TermBasicPageType"; uuid: string}
+    | {__typename?: "TermEventAudience"; uuid: string}
+    | {__typename?: "TermEventFilter"; uuid: string}
+    | {__typename?: "TermOpportunitySponsor"; uuid: string}
+    | {__typename?: "TermOpportunityTagFilter"; uuid: string}
+    | {__typename?: "TermOpportunityType"; uuid: string}
+    | {__typename?: "TermOpportunityUnit"; uuid: string}
+    | {__typename?: "TermPersonFilter"; uuid: string}
+    | {__typename?: "TermPublicationFilter"; uuid: string}
+    | {__typename?: "TermStanfordEventGroup"; uuid: string}
+    | {__typename?: "TermStanfordEventKeyword"; uuid: string}
+    | {__typename?: "TermStanfordEventSubject"; uuid: string}
+    | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10240,6 +10396,7 @@ type FragmentTermInterface_TermStanfordNewsTopic_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10269,6 +10426,7 @@ type FragmentTermInterface_TermStanfordPersonType_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10298,6 +10456,7 @@ type FragmentTermInterface_TermStanfordPublicationTopic_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10327,6 +10486,7 @@ type FragmentTermInterface_TermSuCourseQuarter_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10356,6 +10516,7 @@ type FragmentTermInterface_TermSuCourseSubject_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10385,6 +10546,7 @@ type FragmentTermInterface_TermSuCourseTag_Fragment = {
     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
     | {__typename?: "TermStanfordEventSubject"; uuid: string}
     | {__typename?: "TermStanfordEventType"; uuid: string}
+    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
     | {__typename?: "TermStanfordPersonType"; uuid: string}
     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -10408,6 +10570,7 @@ export type FragmentTermInterfaceFragment =
   | FragmentTermInterface_TermStanfordEventKeyword_Fragment
   | FragmentTermInterface_TermStanfordEventSubject_Fragment
   | FragmentTermInterface_TermStanfordEventType_Fragment
+  | FragmentTermInterface_TermStanfordNewsSpotlightFilter_Fragment
   | FragmentTermInterface_TermStanfordNewsTopic_Fragment
   | FragmentTermInterface_TermStanfordPersonType_Fragment
   | FragmentTermInterface_TermStanfordPublicationTopic_Fragment
@@ -10893,6 +11056,7 @@ export type FragmentNodeStanfordPageFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11151,6 +11315,7 @@ export type FragmentNodeStanfordCourseFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11179,6 +11344,7 @@ export type FragmentNodeStanfordCourseFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11207,6 +11373,7 @@ export type FragmentNodeStanfordCourseFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11247,6 +11414,7 @@ export type FragmentNodeStanfordEventFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11427,6 +11595,7 @@ export type FragmentNodeStanfordEventFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11455,6 +11624,7 @@ export type FragmentNodeStanfordEventFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11549,6 +11719,7 @@ export type FragmentNodeStanfordEventFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11577,6 +11748,7 @@ export type FragmentNodeStanfordEventFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11783,6 +11955,7 @@ export type FragmentNodeStanfordEventSeriesFragment = {
         | {__typename?: "TermStanfordEventKeyword"; uuid: string}
         | {__typename?: "TermStanfordEventSubject"; uuid: string}
         | {__typename?: "TermStanfordEventType"; uuid: string}
+        | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
         | {__typename?: "TermStanfordNewsTopic"; uuid: string}
         | {__typename?: "TermStanfordPersonType"; uuid: string}
         | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -11813,6 +11986,7 @@ export type FragmentNodeStanfordEventSeriesFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12010,6 +12184,7 @@ export type FragmentNodeStanfordNewsFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12215,6 +12390,7 @@ export type FragmentNodeStanfordPersonFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12474,6 +12650,7 @@ export type FragmentNodeStanfordPublicationFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12490,7 +12667,6 @@ export type FragmentNodeStanfordOpportunityFragment = {
   suOppContactName?: string | null
   suOppContactPhone?: any | null
   suOppCourseCode?: Array<string> | null
-  suOppStatus?: boolean | null
   body?: {__typename?: "TextSummary"; processed?: any | null; summary?: any | null} | null
   suOppApplicationDeadline?: {__typename?: "DateTime"; timezone: any; time: any} | null
   suOppCardFooter?: {__typename?: "Text"; processed?: any | null} | null
@@ -12647,8 +12823,6 @@ export type FragmentNodeStanfordOpportunityFragment = {
     name: string
     mediaImage: {__typename?: "Image"; url: string; alt?: string | null; height: number; width: number}
   } | null
-  suOppLearnMore?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
-  suOppOpenDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
   suOppPrerequisites?: {__typename?: "Text"; processed?: any | null} | null
   suOppSource?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
   suOppSponsor?: Array<{
@@ -12671,6 +12845,7 @@ export type FragmentNodeStanfordOpportunityFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12679,7 +12854,6 @@ export type FragmentNodeStanfordOpportunityFragment = {
       | {__typename?: "TermSuCourseTag"; uuid: string}
       | null
   }> | null
-  suOppStartDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
   suOppSummary?: {__typename?: "Text"; processed?: any | null} | null
   suOppTags?: Array<{
     __typename: "TermOpportunityTagFilter"
@@ -12701,6 +12875,7 @@ export type FragmentNodeStanfordOpportunityFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12729,6 +12904,7 @@ export type FragmentNodeStanfordOpportunityFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12757,6 +12933,7 @@ export type FragmentNodeStanfordOpportunityFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12814,6 +12991,7 @@ type FragmentNodeUnion_NodeStanfordCourse_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12842,6 +13020,7 @@ type FragmentNodeUnion_NodeStanfordCourse_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12870,6 +13049,7 @@ type FragmentNodeUnion_NodeStanfordCourse_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -12928,6 +13108,7 @@ type FragmentNodeUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13108,6 +13289,7 @@ type FragmentNodeUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13136,6 +13318,7 @@ type FragmentNodeUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13230,6 +13413,7 @@ type FragmentNodeUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13258,6 +13442,7 @@ type FragmentNodeUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13482,6 +13667,7 @@ type FragmentNodeUnion_NodeStanfordEventSeries_Fragment = {
         | {__typename?: "TermStanfordEventKeyword"; uuid: string}
         | {__typename?: "TermStanfordEventSubject"; uuid: string}
         | {__typename?: "TermStanfordEventType"; uuid: string}
+        | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
         | {__typename?: "TermStanfordNewsTopic"; uuid: string}
         | {__typename?: "TermStanfordPersonType"; uuid: string}
         | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13512,6 +13698,7 @@ type FragmentNodeUnion_NodeStanfordEventSeries_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13727,6 +13914,7 @@ type FragmentNodeUnion_NodeStanfordNews_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13744,7 +13932,6 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
   suOppContactName?: string | null
   suOppContactPhone?: any | null
   suOppCourseCode?: Array<string> | null
-  suOppStatus?: boolean | null
   uuid: string
   title: string
   path?: string | null
@@ -13918,8 +14105,6 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
     name: string
     mediaImage: {__typename?: "Image"; url: string; alt?: string | null; height: number; width: number}
   } | null
-  suOppLearnMore?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
-  suOppOpenDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
   suOppPrerequisites?: {__typename?: "Text"; processed?: any | null} | null
   suOppSource?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
   suOppSponsor?: Array<{
@@ -13942,6 +14127,7 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -13950,7 +14136,6 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermSuCourseTag"; uuid: string}
       | null
   }> | null
-  suOppStartDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
   suOppSummary?: {__typename?: "Text"; processed?: any | null} | null
   suOppTags?: Array<{
     __typename: "TermOpportunityTagFilter"
@@ -13972,6 +14157,7 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14000,6 +14186,7 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14028,6 +14215,7 @@ type FragmentNodeUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14081,6 +14269,7 @@ type FragmentNodeUnion_NodeStanfordPage_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14523,6 +14712,7 @@ type FragmentNodeUnion_NodeStanfordPerson_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14818,6 +15008,7 @@ type FragmentNodeUnion_NodeStanfordPublication_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14864,6 +15055,7 @@ export type FragmentNodeStanfordCourseTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14892,6 +15084,7 @@ export type FragmentNodeStanfordCourseTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14952,6 +15145,7 @@ export type FragmentNodeStanfordEventTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -14997,6 +15191,7 @@ export type FragmentNodeStanfordNewsTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15088,6 +15283,7 @@ export type FragmentNodeStanfordPublicationTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15137,6 +15333,7 @@ export type FragmentNodeStanfordOpportunityTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15165,6 +15362,7 @@ export type FragmentNodeStanfordOpportunityTeaserFragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15203,6 +15401,7 @@ type FragmentNodeTeaserUnion_NodeStanfordCourse_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15231,6 +15430,7 @@ type FragmentNodeTeaserUnion_NodeStanfordCourse_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15294,6 +15494,7 @@ type FragmentNodeTeaserUnion_NodeStanfordEvent_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15345,6 +15546,7 @@ type FragmentNodeTeaserUnion_NodeStanfordNews_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15392,6 +15594,7 @@ type FragmentNodeTeaserUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15420,6 +15623,7 @@ type FragmentNodeTeaserUnion_NodeStanfordOpportunity_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -15521,6 +15725,7 @@ type FragmentNodeTeaserUnion_NodeStanfordPublication_Fragment = {
       | {__typename?: "TermStanfordEventKeyword"; uuid: string}
       | {__typename?: "TermStanfordEventSubject"; uuid: string}
       | {__typename?: "TermStanfordEventType"; uuid: string}
+      | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
       | {__typename?: "TermStanfordNewsTopic"; uuid: string}
       | {__typename?: "TermStanfordPersonType"; uuid: string}
       | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16270,6 +16475,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16298,6 +16504,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16326,6 +16533,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16387,6 +16595,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16585,6 +16794,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16613,6 +16823,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16707,6 +16918,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16735,6 +16947,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -16980,6 +17193,7 @@ export type RouteQuery = {
                     | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                     | {__typename?: "TermStanfordEventSubject"; uuid: string}
                     | {__typename?: "TermStanfordEventType"; uuid: string}
+                    | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                     | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                     | {__typename?: "TermStanfordPersonType"; uuid: string}
                     | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17010,6 +17224,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17246,6 +17461,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17262,7 +17478,6 @@ export type RouteQuery = {
               suOppContactName?: string | null
               suOppContactPhone?: any | null
               suOppCourseCode?: Array<string> | null
-              suOppStatus?: boolean | null
               uuid: string
               title: string
               path?: string | null
@@ -17458,8 +17673,6 @@ export type RouteQuery = {
                 name: string
                 mediaImage: {__typename?: "Image"; url: string; alt?: string | null; height: number; width: number}
               } | null
-              suOppLearnMore?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
-              suOppOpenDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
               suOppPrerequisites?: {__typename?: "Text"; processed?: any | null} | null
               suOppSource?: {__typename?: "Link"; url?: string | null; title?: string | null} | null
               suOppSponsor?: Array<{
@@ -17482,6 +17695,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17490,7 +17704,6 @@ export type RouteQuery = {
                   | {__typename?: "TermSuCourseTag"; uuid: string}
                   | null
               }> | null
-              suOppStartDate?: {__typename?: "DateTime"; timezone: any; time: any} | null
               suOppSummary?: {__typename?: "Text"; processed?: any | null} | null
               suOppTags?: Array<{
                 __typename: "TermOpportunityTagFilter"
@@ -17512,6 +17725,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17540,6 +17754,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17568,6 +17783,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -17624,6 +17840,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18123,6 +18340,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18442,6 +18660,7 @@ export type RouteQuery = {
                   | {__typename?: "TermStanfordEventKeyword"; uuid: string}
                   | {__typename?: "TermStanfordEventSubject"; uuid: string}
                   | {__typename?: "TermStanfordEventType"; uuid: string}
+                  | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
                   | {__typename?: "TermStanfordNewsTopic"; uuid: string}
                   | {__typename?: "TermStanfordPersonType"; uuid: string}
                   | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18670,6 +18889,7 @@ export type StanfordCoursesQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18698,6 +18918,7 @@ export type StanfordCoursesQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18726,6 +18947,7 @@ export type StanfordCoursesQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18813,6 +19035,7 @@ export type StanfordEventsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18900,6 +19123,7 @@ export type StanfordEventsPastEventsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -18969,6 +19193,7 @@ export type StanfordNewsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19043,6 +19268,7 @@ export type StanfordOpportunitiesQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19071,6 +19297,7 @@ export type StanfordOpportunitiesQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19174,6 +19401,7 @@ export type StanfordPublicationsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19247,6 +19475,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19275,6 +19504,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19337,6 +19567,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19386,6 +19617,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19432,6 +19664,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19460,6 +19693,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19557,6 +19791,7 @@ export type StanfordSharedTagsQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19630,6 +19865,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19658,6 +19894,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19720,6 +19957,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19769,6 +20007,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19815,6 +20054,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19843,6 +20083,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}
@@ -19940,6 +20181,7 @@ export type SearchQuery = {
               | {__typename?: "TermStanfordEventKeyword"; uuid: string}
               | {__typename?: "TermStanfordEventSubject"; uuid: string}
               | {__typename?: "TermStanfordEventType"; uuid: string}
+              | {__typename?: "TermStanfordNewsSpotlightFilter"; uuid: string}
               | {__typename?: "TermStanfordNewsTopic"; uuid: string}
               | {__typename?: "TermStanfordPersonType"; uuid: string}
               | {__typename?: "TermStanfordPublicationTopic"; uuid: string}

--- a/src/lib/gql/__generated__/queries.ts
+++ b/src/lib/gql/__generated__/queries.ts
@@ -881,12 +881,6 @@ export const FragmentNodeStanfordOpportunityFragmentDoc = gql`
   suOppImage {
     ...FragmentMediaImage
   }
-  suOppLearnMore {
-    ...FragmentLink
-  }
-  suOppOpenDate {
-    ...FragmentDateTime
-  }
   suOppPrerequisites {
     ...FragmentText
   }
@@ -896,10 +890,6 @@ export const FragmentNodeStanfordOpportunityFragmentDoc = gql`
   suOppSponsor {
     ...FragmentTermInterface
   }
-  suOppStartDate {
-    ...FragmentDateTime
-  }
-  suOppStatus
   suOppSummary {
     ...FragmentText
   }

--- a/src/lib/gql/fragments-nodes.drupal.gql
+++ b/src/lib/gql/fragments-nodes.drupal.gql
@@ -334,12 +334,6 @@ fragment FragmentNodeStanfordOpportunity on NodeStanfordOpportunity {
     suOppImage {
         ...FragmentMediaImage
     }
-    suOppLearnMore {
-        ...FragmentLink
-    }
-    suOppOpenDate {
-        ...FragmentDateTime
-    }
     suOppPrerequisites {
         ...FragmentText
     }
@@ -349,10 +343,6 @@ fragment FragmentNodeStanfordOpportunity on NodeStanfordOpportunity {
     suOppSponsor {
         ...FragmentTermInterface
     }
-    suOppStartDate {
-        ...FragmentDateTime
-    }
-    suOppStatus
     suOppSummary {
         ...FragmentText
     }


### PR DESCRIPTION
# Summary
- Added in a comma to the animated number
- Note: In our style guide on the Stat card, we call out that the number should not include a comma because we add one at the end. https://sitesuserguide.stanford.edu/build/paragraphs/stat-card 

# Review By (Date)
- When time

# Criticality
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to a page with Stat cards. 
3. Verify the commas are added in by the script.
4. Verify the animation works as expected when a decimal. 

# Related Issues/PR's
[- ANES3-383](https://stanfordits.atlassian.net/browse/ANES3-383)
[- https://github.com/SU-SWS/anes-nextjs/pull/19](https://github.com/SU-SWS/anes-nextjs/pull/19)

# Additional Context
- Any extra information for reviewers.
